### PR TITLE
Make testGetCount work in Windows by using line separator static

### DIFF
--- a/src/test/java/com/libzter/a/BaseTest.java
+++ b/src/test/java/com/libzter/a/BaseTest.java
@@ -207,14 +207,14 @@ public abstract class BaseTest {
         a.run(cmdLine.split(" "));
         String out = output.grab().replaceFirst("Operation completed in .+","");
 
-        final String expectedOut = "-----------------\n" +
-                "Message Properties\n" +
-                "Payload:\n" +
-                "test\n" +
-                "-----------------\n" +
-                "Message Properties\n" +
-                "Payload:\n" +
-                "test\n\n";
+        final String expectedOut = "-----------------" + LN +
+                "Message Properties" + LN +
+                "Payload:" + LN +
+                "test" + LN +
+                "-----------------" + LN +
+                "Message Properties" + LN +
+                "Payload:" + LN +
+                "test" + LN + LN;
         assertEquals(expectedOut,out);
     }
 


### PR DESCRIPTION
Use the LN static as line separator to build up the expectedOut string
so that tests work also on Windows.