### PR TITLE
Fixed Move X number of messages bug

### DIFF
--- a/src/main/java/co/nordlander/a/A.java
+++ b/src/main/java/co/nordlander/a/A.java
@@ -114,7 +114,7 @@ A {
 		opts.addOption(CMD_NON_PERSISTENT,"non-persistent",false,"Set message to non persistent.");
 		opts.addOption(CMD_REPLY_TO,"reply-to",true,"Set reply to destination, i.e. queue:reply");
 		opts.addOption(CMD_OUTPUT,"output",true,"file to write payload to. If multiple messages, a -1.<ext> will be added to the file. BytesMessage will be written as-is, TextMessage will be written in UTF-8");
-		opts.addOption(CMD_COUNT,"count",true,"A number of messages to browse,get or put (put will put the same message <count> times). 0 means all messages.");
+		opts.addOption(CMD_COUNT,"count",true,"A number of messages to browse,get,move or put (put will put the same message <count> times). 0 means all messages.");
 		opts.addOption(CMD_JMS_HEADERS,"jms-headers",false,"Print JMS headers");
 		opts.addOption(CMD_COPY_QUEUE,"copy-queue",true,"Copy all messages from this to target. Limited by maxBrowsePageSize in broker settings (default 400).");
 		opts.addOption(CMD_MOVE_QUEUE,"move-queue",true,"Move all messages from this to target");
@@ -211,8 +211,8 @@ A {
 			mq = tsess.createConsumer(q);
 		}
 		int count = Integer.parseInt(cmdLine.getOptionValue(CMD_COUNT,DEFAULT_COUNT_ALL));
-		int i = 0,j = 0;
-		while(i < count || count == 0 ){
+		int j = 0;
+		while(j < count || count == 0 ){
 			Message msg = mq.receive(100L);
 			if( msg == null){
 				break;

--- a/src/test/java/co/nordlander/a/BaseTest.java
+++ b/src/test/java/co/nordlander/a/BaseTest.java
@@ -199,6 +199,52 @@ public abstract class BaseTest {
         assertNull(msg);
     }
 
+   /**
+     * Test that all messages but one message is moved from one queue to the other.
+     * @throws Exception
+     */
+    @Test
+    public void testMoveCountQueue() throws Exception{
+        final String cmdLine = getConnectCommand() + "-" + CMD_MOVE_QUEUE + " SOURCE.QUEUE " + "-c" + " 4 TARGET.QUEUE";
+        MessageProducer mp = session.createProducer(sourceQueue);
+
+        mp.send(testMessage);
+        mp.send(testMessage);
+        mp.send(testMessage);
+        mp.send(testMessage);
+        mp.send(testMessage);
+	
+        a.run(cmdLine.split(" "));
+        MessageConsumer mc = session.createConsumer(sourceQueue);
+        TextMessage msg = null;
+
+	// Verify 1 messages are left on source queue
+	msg = (TextMessage)mc.receive(TEST_TIMEOUT);
+        assertNotNull(msg);
+
+        // Verify NO messages are left on source queue
+        msg = (TextMessage)mc.receive(TEST_TIMEOUT);
+        assertNull(msg);
+
+        // Verify 4 messages is moved to target queue
+        mc = session.createConsumer(targetQueue);
+
+        msg = (TextMessage)mc.receive(TEST_TIMEOUT);
+        assertNotNull(msg);
+        msg = (TextMessage)mc.receive(TEST_TIMEOUT);
+        assertNotNull(msg);
+        msg = (TextMessage)mc.receive(TEST_TIMEOUT);
+        assertNotNull(msg);
+        msg = (TextMessage)mc.receive(TEST_TIMEOUT);
+        assertNotNull(msg);
+
+	
+        // Verify NO messages are left on target queue
+        msg = (TextMessage)mc.receive(TEST_TIMEOUT);
+        assertNull(msg);
+    }
+
+
     @Test
     public void testGetCount() throws Exception{
         final String cmdLine = getConnectCommand() + "-" + CMD_GET + " -" + CMD_COUNT + "2 TEST.QUEUE";


### PR DESCRIPTION
Fixed a bug with -M and -c not working correctly. Now it is possible to
move x amount of messages from one queue to another.
Testcase added.